### PR TITLE
Improve nf-test files detection Python script

### DIFF
--- a/.github/python/include.yaml
+++ b/.github/python/include.yaml
@@ -1,0 +1,10 @@
+".":
+  - .github/workflows/**
+  - nf-test.config
+  - nextflow.config
+tests:
+  - assets/*
+  - bin/*
+  - conf/*
+  - main.nf
+  - nextflow_schema.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Install gitpython find changed files
         run: |
           python -m pip install --upgrade pip
-          pip install gitpython
+          pip install gitpython pyyaml
 
       - name: nf-test list nf_test_files
         id: list
@@ -132,7 +132,9 @@ jobs:
 
   confirm-pass:
     runs-on: ubuntu-latest
-    needs: [test]
+    needs:
+      - changes
+      - test
     if: always()
     steps:
       - name: All tests ok


### PR DESCRIPTION
Improvements to detect nf-test files Python script

Additions:
 - include.yaml file to specify files to include or exclude from test sets
 - Will include additional tests if major files have been modified, e.g. the .github/workflows/* files
 - Uses globbing for exclude statement to match multiple files.

Changes:
 - bump setup-nextflow
 - Adds pyyaml as dependency
 - Uses pathlib.Path object where possible to prevent coercion back and forth between strings
 - Splits find_files into two functions, find_changed_files and detect_nf_test_files

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/phageannotator/tree/master/.github/CONTRIBUTING.md)
- [ ] If necessary, also make a PR on the nf-core/phageannotator _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [x] Make sure your code lints (`nf-core lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
